### PR TITLE
Add retry logic with exponential backoff to API client

### DIFF
--- a/nodejs/tests/api.spec.ts
+++ b/nodejs/tests/api.spec.ts
@@ -43,7 +43,7 @@ test('should throw axios error object if set wrapResponseErrors to false', async
   })
 
   server.use(
-    rest.get('https://api.hackmd.io/v1/me', (req, res, ctx) => {
+    rest.get('https://api.hackmd.io/v1/me', (req: any, res: (arg0: any) => any, ctx: { status: (arg0: number) => any }) => {
       return res(ctx.status(429))
     }),
   )


### PR DESCRIPTION
Add retry logic with exponential backoff to API client:
- Implemented retry interceptor for handling transient errors.
- Added exponential backoff mechanism with a base delay of 100ms.
- Updated error handling to include retryable conditions (5xx and 429).

[#382](https://github.com/hackmdio/hackmd-io-issues/issues/382)