### PR TITLE
Publish pre-release(beta) build automatically

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,85 @@
+name: Pre-release to NPM
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  pre-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: nodejs/package-lock.json
+
+      - name: Install dependencies
+        working-directory: nodejs
+        run: npm ci
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Generate pre-release version
+        working-directory: nodejs
+        run: |
+          # Get current version from package.json
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          
+          # Get short commit hash
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          
+          # Get current timestamp
+          TIMESTAMP=$(date +%Y%m%d%H%M%S)
+          
+          # Create pre-release version: current-version-beta.timestamp.sha
+          PRE_RELEASE_VERSION="${CURRENT_VERSION}-beta.${TIMESTAMP}.${SHORT_SHA}"
+          
+          echo "Pre-release version: $PRE_RELEASE_VERSION"
+          echo "PRE_RELEASE_VERSION=$PRE_RELEASE_VERSION" >> $GITHUB_ENV
+          
+          # Update package.json with pre-release version
+          npm version $PRE_RELEASE_VERSION --no-git-tag-version
+
+      - name: Build
+        working-directory: nodejs
+        run: npm run build
+
+      - name: Publish pre-release to NPM
+        working-directory: nodejs
+        run: npm publish --tag beta --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub pre-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ env.PRE_RELEASE_VERSION }}" \
+            --title "Pre-release v${{ env.PRE_RELEASE_VERSION }}" \
+            --notes "🚀 **Pre-release from develop branch**
+
+          This is an automated pre-release build from the develop branch.
+
+          **Changes:**
+          - Commit: ${{ github.sha }}
+          - Branch: ${{ github.ref_name }}
+
+          **Installation:**
+          \`\`\`bash
+          npm install @hackmd/api@beta
+          \`\`\`
+
+          **Note:** This is a pre-release version and may contain unstable features." \
+            --prerelease 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -31,4 +33,19 @@ jobs:
         working-directory: nodejs
         run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} 
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Extract version from tag
+        run: |
+          # Extract version from tag (remove 'v' prefix)
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Extracted version: $VERSION"
+
+      - name: Create draft release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "Release v${{ env.VERSION }}" \
+            --draft


### PR DESCRIPTION
This pull request introduces new workflows and enhancements to the CI/CD pipeline for managing pre-releases and releases. The most notable changes include adding a new workflow for automating pre-releases to NPM from the `develop` branch, and improving the existing `publish` workflow by extracting the version from tags and creating draft releases on GitHub.

### New Workflow for Pre-Releases:
* [`.github/workflows/pre-release.yml`](diffhunk://#diff-8f0c4d810b263ab478547020c847ee0297cc98c11c67fc2209ce604e52719607R1-R85): Added a new workflow to automate pre-releases to NPM. It generates a pre-release version from the `develop` branch, updates `package.json`, builds the project, publishes the pre-release to NPM with a `beta` tag, and creates a corresponding GitHub pre-release.

### Enhancements to the Publish Workflow:
* `.github/workflows/publish.yml`:
  - Added `fetch-depth: 0` to the `actions/checkout@v4` step to ensure full Git history is available.
  - Introduced a step to extract the version from the Git tag and store it in an environment variable.
  - Added a step to create a draft release on GitHub using the extracted version.